### PR TITLE
Auto-Generated Doc Updates from Code PR

### DIFF
--- a/cmd/argocd/commands/cluster.go
+++ b/cmd/argocd/commands/cluster.go
@@ -502,7 +502,10 @@ func printClusterServers(clusters []argoappv1.Cluster) {
 
 // NewClusterListCommand returns a new instance of an `argocd cluster rm` command
 func NewClusterListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Command {
-	var output string
+	var (
+		output string
+		quiet  bool
+	)
 	command := &cobra.Command{
 		Use:   "list",
 		Short: "List configured clusters",
@@ -513,6 +516,13 @@ func NewClusterListCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comman
 			defer utilio.Close(conn)
 			clusters, err := clusterIf.List(ctx, &clusterpkg.ClusterQuery{})
 			errors.CheckError(err)
+			if quiet {
+				// Quiet mode: print only cluster names, one per line
+				for _, c := range clusters.Items {
+					fmt.Println(c.Name)
+				}
+				return
+			}
 			switch output {
 			case "yaml", "json":
 				err := PrintResourceList(clusters.Items, output, false)
@@ -541,9 +551,13 @@ argocd cluster list -o yaml --server <ARGOCD_SERVER_ADDRESS>
 # List Clusters that have been added to your Argo CD 
 argocd cluster list -o server <ARGOCD_SERVER_ADDRESS>
 
+# List only cluster names (quiet mode)
+argocd cluster list --quiet
+
 `,
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|server")
+	command.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only display cluster names")
 	return command
 }
 

--- a/cmd/argocd/commands/version.go
+++ b/cmd/argocd/commands/version.go
@@ -19,9 +19,10 @@ import (
 // NewVersionCmd returns a new `version` command to be used as a sub-command to root
 func NewVersionCmd(clientOpts *argocdclient.ClientOptions, serverVersion *version.VersionMessage) *cobra.Command {
 	var (
-		short  bool
-		client bool
-		output string
+		short   bool
+		client  bool
+		output  string
+		verbose bool
 	)
 
 	versionCmd := cobra.Command{
@@ -38,6 +39,9 @@ func NewVersionCmd(clientOpts *argocdclient.ClientOptions, serverVersion *versio
 
   # Print only client and server core version strings in YAML format
   argocd version --short -o yaml
+
+  # Print version with additional build and dependency details
+  argocd version --verbose
 `,
 		Run: func(cmd *cobra.Command, _ []string) {
 			ctx := cmd.Context()
@@ -89,6 +93,7 @@ func NewVersionCmd(clientOpts *argocdclient.ClientOptions, serverVersion *versio
 	versionCmd.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide|short")
 	versionCmd.Flags().BoolVar(&short, "short", false, "print just the version number")
 	versionCmd.Flags().BoolVar(&client, "client", false, "client version only (no server required)")
+	versionCmd.Flags().BoolVar(&verbose, "verbose", false, "include additional build and dependency information")
 	return &versionCmd
 }
 

--- a/docs/operator-manual/cluster-management.md
+++ b/docs/operator-manual/cluster-management.md
@@ -13,6 +13,13 @@ If you're unsure about the context names, run `kubectl config get-contexts` to g
 This will connect to the cluster and install the necessary resources for ArgoCD to connect to it.
 Note that you will need privileged access to the cluster.
 
+## Listing clusters
+
+Run `argocd cluster list`.
+
+To only display cluster names, you can use the quiet mode:
+`argocd cluster list --quiet`
+
 ## Removing a cluster
 
 Run `argocd cluster rm context-name`.

--- a/docs/operator-manual/server-commands/argocd-server_version.md
+++ b/docs/operator-manual/server-commands/argocd-server_version.md
@@ -11,8 +11,9 @@ argocd-server version [flags]
 ### Options
 
 ```
-  -h, --help    help for version
-      --short   print just the version number
+  -h, --help      help for version
+      --short     print just the version number
+      --verbose   include additional build and dependency information
 ```
 
 ### Options inherited from parent commands
@@ -43,4 +44,3 @@ argocd-server version [flags]
 ### SEE ALSO
 
 * [argocd-server](argocd-server.md)	 - Run the ArgoCD API server
-

--- a/docs/user-guide/commands/argocd_cluster_list.md
+++ b/docs/user-guide/commands/argocd_cluster_list.md
@@ -27,6 +27,8 @@ argocd cluster list -o yaml --server <ARGOCD_SERVER_ADDRESS>
 # List Clusters that have been added to your Argo CD 
 argocd cluster list -o server <ARGOCD_SERVER_ADDRESS>
 
+# List only cluster names (quiet mode)
+argocd cluster list --quiet
 
 ```
 
@@ -35,6 +37,7 @@ argocd cluster list -o server <ARGOCD_SERVER_ADDRESS>
 ```
   -h, --help            help for list
   -o, --output string   Output format. One of: json|yaml|wide|server (default "wide")
+  -q, --quiet           Only display cluster names
 ```
 
 ### Options inherited from parent commands
@@ -71,4 +74,3 @@ argocd cluster list -o server <ARGOCD_SERVER_ADDRESS>
 ### SEE ALSO
 
 * [argocd cluster](argocd_cluster.md)	 - Manage cluster credentials
-

--- a/docs/user-guide/commands/argocd_version.md
+++ b/docs/user-guide/commands/argocd_version.md
@@ -23,6 +23,8 @@ argocd version [flags]
   # Print only client and server core version strings in YAML format
   argocd version --short -o yaml
 
+  # Print version with additional build and dependency details
+  argocd version --verbose
 ```
 
 ### Options
@@ -51,6 +53,7 @@ argocd version [flags]
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
       --username string                Username for basic authentication to the API server
+      --verbose                        include additional build and dependency information
 ```
 
 ### Options inherited from parent commands
@@ -87,4 +90,3 @@ argocd version [flags]
 ### SEE ALSO
 
 * [argocd](argocd.md)	 - argocd controls a Argo CD server
-


### PR DESCRIPTION
This PR updates the following documentation files based on code changes:

- `docs/user-guide/commands/argocd_version.md`
- `docs/user-guide/commands/argocd_cluster_list.md`
- `docs/operator-manual/cluster-management.md`
- `docs/operator-manual/server-commands/argocd-server_version.md`

---
**Source:**
- PR: https://github.com/csoceanu/argo-cd/pull/10
- Commit: `6214626`

*Assisted by Gemini*