### PR TITLE
feat: add --sync-warn-message flag to argocd app sync

### DIFF
--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -2100,6 +2100,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 		output                  string
 		appNamespace            string
 		ignoreNormalizerOpts    normalizers.IgnoreNormalizerOpts
+		syncWarnMessage         string
 	)
 	command := &cobra.Command{
 		Use:   "sync [APPNAME... | -l selector | --project project-name]",
@@ -2410,6 +2411,9 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 
 					if !dryRun {
 						if !opState.Phase.Successful() {
+							if syncWarnMessage != "" {
+								log.Warnf("Sync warning for %s: %s", appQualifiedName, syncWarnMessage)
+							}
 							log.Fatalf("Operation has completed with phase: %s", opState.Phase)
 						} else if len(selectedResources) == 0 && app.Status.Sync.Status != argoappv1.SyncStatusCodeSynced {
 							// Only get resources to be pruned if sync was application-wide and final status is not synced
@@ -2453,6 +2457,7 @@ func NewApplicationSyncCommand(clientOpts *argocdclient.ClientOptions) *cobra.Co
 	command.Flags().StringArrayVar(&revisions, "revisions", []string{}, "Show manifests at specific revisions for source position in source-positions")
 	command.Flags().Int64SliceVar(&sourcePositions, "source-positions", []int64{}, "List of source positions. Default is empty array. Counting start at 1.")
 	command.Flags().StringArrayVar(&sourceNames, "source-names", []string{}, "List of source names. Default is an empty array.")
+	command.Flags().StringVar(&syncWarnMessage, "sync-warn-message", "", "Custom warning message to display when sync operation fails. Useful for adding context about known issues or required manual steps.")
 	return command
 }
 


### PR DESCRIPTION
## Summary
- Adds a new `--sync-warn-message` CLI flag to `argocd app sync`
- Displays a custom warning message when a sync operation fails
- Useful for providing context about known issues or required manual steps

## Test plan
- [ ] Verify the flag is registered and appears in `argocd app sync --help`
- [ ] Test with a failing sync to confirm warning message is displayed
- [ ] Test without the flag to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)