### PR TITLE
chore: Update documentation semantic indexes

### DIFF
--- a/docs/.doc-index/manifest.json
+++ b/docs/.doc-index/manifest.json
@@ -178,7 +178,7 @@
       }
     },
     "operator-manual/server-commands": {
-      "built": "2026-06-22T17:58:08.038990",
+      "built": "2026-06-22T18:21:59.342832",
       "doc_hashes": {
         "operator-manual/server-commands/argocd-dex_rundex.md": "1bf3c2c24e834df5fcf28bb0cd55f56014e484d565224dd2b6864695e0bb7e71",
         "operator-manual/server-commands/argocd-repo-server.md": "b1d2a52781a58cacb70a90086286ec4a402d9af5b981ed0eebfc3bb9d1d1cf7b",
@@ -187,7 +187,7 @@
         "operator-manual/server-commands/argocd-server_version.md": "f4aca5cb61fb417b3be7397487450863c4a4847a6f7333e4006c876d6b48bb8d",
         "operator-manual/server-commands/argocd-server.md": "6d3c8869b471a8833278164383accc1a9cee7f67244094f109513d4612a116cc",
         "operator-manual/server-commands/argocd-applicationset-controller.md": "f3dd07675ad55b6bc8f3e030e9c116da548d6d41ea7a341f68d442c78902d952",
-        "operator-manual/server-commands/argocd-application-controller.md": "4bae9e14eb3e1babbd16ce564fbc9a079f881d5b1861ad7ebb1e026f0113a880",
+        "operator-manual/server-commands/argocd-application-controller.md": "149e199be7d1cba7dc9197e686b011a7e343e7514d1994e808c764e23d7c5237",
         "operator-manual/server-commands/additional-configuration-method.md": "13a3178849bff4e7504ad52e2de84d7b61a8a6e8d32fa444a1b1f8cb74010b2d"
       }
     },
@@ -512,5 +512,5 @@
       }
     }
   },
-  "updated": "2026-06-22T18:00:07.406800"
+  "updated": "2026-06-22T18:21:59.363602"
 }

--- a/docs/.doc-index/operator-manual-server-commands.index.md
+++ b/docs/.doc-index/operator-manual-server-commands.index.md
@@ -1,44 +1,41 @@
 # OPERATOR-MANUAL/SERVER-COMMANDS Documentation Index
 
 ## Overview
-This documentation area provides comprehensive command references and configuration guides for the core server-side components of Argo CD. It details the operational flags, environment settings, and configuration methods required to run the API server, repository server, application controllers, and identity management (Dex) utilities.
+This documentation area provides a comprehensive reference for the command-line interfaces and configuration options of the core Argo CD server-side components. It details the operational flags, environment-specific settings, and internal utility commands required to run the API server, state controllers, repository management services, and authentication providers.
 
 ## Files Summary
-* **argocd-dex_rundex.md**: Provides the command reference for running the Dex server using settings derived from Argo CD’s internal ConfigMaps and Secrets.
-* **argocd-repo-server.md**: Details the Repository Server, which handles Git repository local caching and the generation of Kubernetes manifests from source code.
-* **argocd-dex.md**: Serves as the parent entry point for internal Dex-related utility tools used within the Argo CD ecosystem.
-* **argocd-dex_gendexcfg.md**: Explains the command used to manually generate a Dex configuration file based on current Argo CD settings.
-* **argocd-server_version.md**: Document the specific flags for the version subcommand of the API server, used to retrieve build and version metadata.
-* **argocd-server.md**: The primary reference for the Argo CD API server, covering gRPC/REST endpoints, authentication, OIDC, and global cache settings.
-* **argocd-applicationset-controller.md**: Describes the controller responsible for managing ApplicationSet resources and automating multi-application generation via SCM/PR generators.
-* **argocd-application-controller.md**: Detailed reference for the core application controller that reconciles the live state of the cluster with the desired state in Git.
-* **additional-configuration-method.md**: Explains how to use the `argocd-cmd-params-cm.yaml` ConfigMap to configure server components globally as an alternative to CLI flags.
+*   **argocd-application-controller.md**: Detailed reference for the core controller that monitors live clusters and reconciles them with the desired state defined in Git.
+*   **argocd-applicationset-controller.md**: Reference for the controller that automates the generation of Argo CD Applications using various generators (SCM, Git, etc.).
+*   **argocd-dex.md**: The root command reference for the integrated Dex identity service utility tools.
+*   **argocd-dex_gendexcfg.md**: Documentation for the utility that transforms Argo CD ConfigMap settings into a valid Dex configuration file.
+*   **argocd-dex_rundex.md**: Instructions for running the Dex server using settings dynamically pulled from Argo CD’s Kubernetes secrets and configmaps.
+*   **argocd-repo-server.md**: Reference for the service responsible for cloning repositories, caching manifests, and invoking config management tools like Helm or Kustomize.
+*   **argocd-server.md**: Primary reference for the Argo CD API server, which hosts the Web UI, serves the gRPC/REST API, and manages authentication.
+*   **argocd-server_version.md**: Specific documentation for the command used to retrieve the API server's version and build information.
+*   **additional-configuration-method.md**: Explains how to use the `argocd-cmd-params-cm.yaml` ConfigMap as an alternative to command-line flags for global configuration.
 
 ## Code Changes That Would Require Documentation Updates
-* **Flag Modifications**: Adding, renaming, or removing CLI flags in the Go source code for any server component (e.g., adding a new `--enable-feature-x` flag).
-* **Default Value Changes**: Changing the default value of any configuration parameter (e.g., increasing `default-cache-expiration` or changing a default port).
-* **New Subcommands**: Adding new sub-functional commands to `argocd-server`, `argocd-dex`, or other binaries.
-* **Cache Logic Updates**: Modifications to how Redis, repository state, or OIDC state is cached or expired.
-* **Integration Extensions**: Adding support for new SCM providers, OCI media types, or OpenTelemetry (OTLP) attributes.
-* **Scaling & Performance Tuning**: Changes to parallelism limits (webhook, manifest generation, or kubectl execution) and sharding methods.
-* **Security Enhancements**: Updates to TLS cipher suites, minimum/maximum TLS versions, or RBAC impersonation logic.
-* **ConfigMap Schema Changes**: Updating the `argocd-cmd-params-cm` mapping logic or adding new prefixes for component configuration.
-* **Experimental Features**: Transitioning experimental features (like Hydrator or Progressive Syncs) to GA or changing their activation flags.
+*   **CLI Flag Modifications**: Adding, removing, or renaming flags in the Go source code (typically via the Cobra library) for any server component.
+*   **Default Value Adjustments**: Changing default port numbers, timeout durations, or cache expiration intervals in the component initialization logic.
+*   **New Feature Toggles**: Introducing new experimental features (e.g., Hydrator, Progressive Syncs, or Server-Side Diff) that require a flag to enable.
+*   **Caching Logic Updates**: Modifying how components interact with Redis or changing the schema of `argocd-cmd-params-cm.yaml`.
+*   **Security/TLS Policy Changes**: Updating supported TLS versions, cipher suites, or introducing new authentication impersonation parameters.
+*   **Manifest Generation Parameters**: Changing how the repo-server handles OCI media types, Helm archive limits, or symlink security policies.
+*   **Scaling and Sharding**: Implementing new sharding methods (e.g., consistent hashing) or reconciliation algorithms in the application controller.
+*   **Metric and Trace Extensions**: Adding new OpenTelemetry (OTLP) attributes or Prometheus metric labels to the server components.
 
 ## Key Technical Concepts
-* **Server Components**: `argocd-server`, `argocd-repo-server`, `argocd-application-controller`, `argocd-applicationset-controller`, `argocd-dex`.
-* **Caching Infrastructure**: Redis, Redis Sentinel, `repo-cache-expiration`, `app-state-cache-expiration`, compression algorithms (gzip/none).
-* **Authentication & Identity**: Dex, OIDC, JWT tokens, impersonation (`--as`, `--as-group`), Basic Auth.
-* **Manifest Generation**: Helm, OCI, Git hidden directories, `allow-oob-symlinks`, manifest size limits.
-* **Observability**: OpenTelemetry (OTLP), Prometheus metrics, log formats (JSON/Text), log levels.
-* **Reconciliation & Sync**: Self-healing backoff, sharding methods (legacy, round-robin, consistent-hashing), hard resync, workqueue tuning.
-* **Global Configuration**: `argocd-cmd-params-cm`, `kubeconfig` contexts, namespace scoping.
+*   **Controllers**: `argocd-application-controller` (reconciliation), `argocd-applicationset-controller` (automation).
+*   **Manifest Management**: `argocd-repo-server`, manifest generation, OCI/Helm caching, parallelism limits.
+*   **API & Auth**: `argocd-server`, gRPC/REST, Dex, OIDC, RBAC impersonation (`--as`), Bearer tokens.
+*   **Configuration Management**: `argocd-cmd-params-cm.yaml`, prefix-based flag mapping (e.g., `controller.`, `reposerver.`).
+*   **High Availability**: Controller sharding (legacy, round-robin, consistent-hashing), Redis Sentinel, leader election.
+*   **Observability**: Log formats (json/text), OTLP (OpenTelemetry) tracing, Prometheus metrics endpoints.
+*   **Networking**: TLS min/max versions, cipher suites, proxy URLs, and gRPC/HTTP endpoint configuration.
 
 ## Related Components
-* **Argo CD API Server**: The central gateway for UI and CLI interaction.
-* **Repository Server**: The internal manifest generation engine.
-* **Application/ApplicationSet Controllers**: The logic engines for state reconciliation.
-* **Dex Server**: The integrated identity provider for SSO.
-* **Redis**: The state and manifest cache provider.
-* **Kubernetes API Server**: The underlying platform where Argo CD reconciles resources.
-* **OpenTelemetry Collector**: External system for receiving traces and metrics.
+*   **Redis**: Used for state caching across the API server, repo-server, and controllers.
+*   **Kubernetes API Server**: The primary target for resource reconciliation and the source of truth for Argo CD configurations.
+*   **Dex**: The internal identity provider service for OIDC/SAML integration.
+*   **Git/OCI Providers**: External systems that host the desired state manifests managed by the repo-server.
+*   **OpenTelemetry Collector**: External sink for traces and telemetry data generated by server components.


### PR DESCRIPTION
This PR updates documentation semantic indexes.

These are auto-generated indexes and file summaries used by the code-to-docs action to speed up documentation file discovery.

*Auto-generated by code-to-docs action*